### PR TITLE
Gh 838 GafferConnector level headers

### DIFF
--- a/python-shell/src/gafferpy/gaffer_connector.py
+++ b/python-shell/src/gafferpy/gaffer_connector.py
@@ -31,7 +31,7 @@ class GafferConnector:
     This class is initialised with a host to connect to.
     """
 
-    def __init__(self, host, verbose=False):
+    def __init__(self, host, verbose=False, headers={}):
         """
         This initialiser sets up a connection to the specified Gaffer server.
 
@@ -40,29 +40,38 @@ class GafferConnector:
         """
         self._host = host
         self._verbose = verbose
+        self._headers = headers
 
         # Create the opener
         self._opener = urllib.request.build_opener(
             urllib.request.HTTPHandler())
 
-    def execute_operation(self, operation, headers={}):
+    def execute_operation(self, operation, headers=None):
         """
         This method queries Gaffer with the single provided operation.
         """
+        # If headers are not specified use those set at class initilisation
+        if headers is None:
+            headers = self._headers
         return self.execute_operations([operation], headers)
 
-    def execute_operations(self, operations, headers={}):
+    def execute_operations(self, operations, headers=None):
         """
         This method queries Gaffer with the provided array of operations.
         """
+        # If headers are not specified use those set at class initilisation
+        if headers is None:
+            headers = self._headers
         return self.execute_operation_chain(g.OperationChain(operations),
                                             headers)
 
-    def execute_operation_chain(self, operation_chain, headers={}):
+    def execute_operation_chain(self, operation_chain, headers=None):
         """
         This method queries Gaffer with the provided operation chain.
         """
-
+        # If headers are not specified use those set at class initialisation
+        if headers is None:
+            headers = self._headers
         # Construct the full URL path to the Gaffer server
         url = self._host + '/graph/operations/execute'
 
@@ -103,8 +112,11 @@ class GafferConnector:
 
         return g.JsonConverter.from_json(result)
 
-    def execute_get(self, operation, headers={}):
+    def execute_get(self, operation, headers=None):
         url = self._host + operation.get_url()
+        # If headers are not specified use those set at class initilisation
+        if headers is None:
+            headers = self._headers
         headers['Content-Type'] = 'application/json;charset=utf-8'
         request = urllib.request.Request(url, headers=headers)
 
@@ -120,8 +132,11 @@ class GafferConnector:
 
         return response.read().decode('utf-8')
 
-    def is_operation_supported(self, operation=None, headers={}):
+    def is_operation_supported(self, operation=None, headers=None):
         url = self._host + '/graph/operations/' + operation.get_operation()
+        # If headers are not specified use those set at class initilisation
+        if headers is None:
+            headers = self._headers
         headers['Content-Type'] = 'application/json;charset=utf-8'
 
         request = urllib.request.Request(url, headers=headers)

--- a/python-shell/src/test/test_connector.py
+++ b/python-shell/src/test/test_connector.py
@@ -43,6 +43,41 @@ class GafferConnectorTest(unittest.TestCase):
                     "SOURCE")],
             elements)
 
+    def test_dummy_header(self):
+        """Test that the addition of a dummy header does not effect the standard test"""
+        gc = gaffer_connector.GafferConnector('http://localhost:8080/rest/latest', headers={"dummy_Header": "value"})
+        elements = gc.execute_operation(
+            g.GetElements(
+                input=[
+                    g.EntitySeed('M5:10')
+                ],
+                view=g.View(
+                    edges=[
+                        g.ElementDefinition(
+                            group='JunctionLocatedAt'
+                        )
+                    ]
+                )
+            )
+        )
+
+        self.assertEqual(
+            [g.Edge("JunctionLocatedAt", "M5:10", "390466,225615", True, {},
+                    "SOURCE")],
+            elements)
+
+    def test_class_initilisation(self):
+        """Test that the gaffer_connector class is correctly initialised with instance attributes"""
+        host = 'http://localhost:8080/rest/latest',
+        verbose = False,
+        headers = {"dummy_Header": "value"}
+        gc = gaffer_connector.GafferConnector(host, verbose, headers)
+
+        actuals = [gc._host, gc._verbose, gc._headers]
+        expecteds = [host, verbose, headers]
+
+        for actual, expected in zip(actuals, expecteds):
+            self.assertEqual(actual, expected)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I have added in two additional tests to try and cover some of the cases where headers crop up. Ideally I would show header inheritance from the GafferConnector class initialisation through to the methods.

I have used this modification to pass authentication headers in a custom API setup, however, I am unable to replicate this in UnitTest. You could visually verify by adding in 'if self._verbose: print(headers)' but this would be sub-optimal.