### PR TITLE
Gh 842 - GetExports get_exports param changed to mandatory

### DIFF
--- a/python-shell/src/gafferpy/gaffer_operations.py
+++ b/python-shell/src/gafferpy/gaffer_operations.py
@@ -904,7 +904,7 @@ class GetExports(Operation):
     CLASS = 'uk.gov.gchq.gaffer.operation.impl.export.GetExports'
 
     def __init__(self,
-                 get_exports=None,
+                 get_exports,
                  options=None):
         super().__init__(
             _class_name=self.CLASS,
@@ -919,11 +919,7 @@ class GetExports(Operation):
     def to_json(self):
         operation = super().to_json()
 
-        if self.get_exports is not None:
-            exports = []
-            for export in self.get_exports:
-                exports.append(export.to_json())
-            operation['getExports'] = exports
+        operation['getExports'] = [export.to_json() for export in self.get_exports]
 
         return operation
 


### PR DESCRIPTION
Pull request covers issue #842 

Modified g.GetExports() to make the get_exports parameter mandatory as a GetExports operation with no provided exports always returns an empty map. 