### PR TITLE
Session headers are now updated instead of overwritten

### DIFF
--- a/fish-bowl/fishbowl/connector.py
+++ b/fish-bowl/fishbowl/connector.py
@@ -8,15 +8,14 @@ from fishbowl.util import to_json
 
 class GafferConnector:
     def __init__(self, host, verbose=False,
-                 headers=None, auth=None, cert=None,
+                 headers={}, auth=None, cert=None,
                  verify=True, proxies={}, protocol=None):
         self._host = host
         self._verbose = verbose
 
         # Create the session
         self._session = requests.Session()
-        if headers:
-            self._session.headers = headers
+        self._session.headers.update(headers)
         self._session.auth = auth
         self._session.cert = cert
         self._session.verify = verify

--- a/python-shell/src/gafferpy/gaffer_connector_requests.py
+++ b/python-shell/src/gafferpy/gaffer_connector_requests.py
@@ -33,7 +33,7 @@ class GafferConnector:
     """
 
     def __init__(self, host, verbose=False,
-                 headers=None, auth=None, cert=None,
+                 headers={}, auth=None, cert=None,
                  verify=True, proxies={}, protocol=None):
         """
         This initialiser sets up a connection to the specified Gaffer server.
@@ -46,8 +46,7 @@ class GafferConnector:
 
         # Create the session
         self._session = requests.Session()
-        if headers:
-            self._session.headers = headers
+        self._session.headers.update(headers)
         self._session.auth = auth
         self._session.cert = cert
         self._session.verify = verify

--- a/python-shell/src/test/test_connector.py
+++ b/python-shell/src/test/test_connector.py
@@ -241,8 +241,8 @@ class GafferConnectorTest(unittest.TestCase):
 
     def test_class_initilisation(self):
         """Test that the gaffer_connector class is correctly initialised with instance attributes"""
-        host = 'http://localhost:8080/rest/latest',
-        verbose = False,
+        host = 'http://localhost:8080/rest/latest'
+        verbose = False
         headers = {"dummy_Header": "value"}
         gc = gaffer_connector.GafferConnector(host, verbose, headers)
 

--- a/python-shell/src/test/test_connector_requests.py
+++ b/python-shell/src/test/test_connector_requests.py
@@ -241,9 +241,9 @@ class GafferConnectorTest(unittest.TestCase):
 
     def test_class_initilisation(self):
         """Test that the gaffer_connector class is correctly initialised with instance attributes"""
-        host = 'http://localhost:8080/rest/latest',
-        verbose = False,
-        headers = {"dummy_Header": "value"}
+        host = 'http://localhost:8080/rest/latest'
+        verbose = False
+        headers = {'User-Agent': 'python-requests/2.25.1', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive', 'dummy_Header': 'value'}
         gc = gaffer_connector_requests.GafferConnector(host, verbose, headers)
 
         actuals = [gc._host, gc._verbose, gc._session.headers]


### PR DESCRIPTION
When a user provides headers, these will be added to the session default headers instead of overwriting them:
`{'User-Agent': 'python-requests/2.25.1', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive'}`.

This is because the user agent information may be useful. However, if a user doesn't want to send it they can still easily not by setting `conn._session.headers = None`.