### PR TITLE
gh-927: Provided mechanism for users to override seed types when using the UI

### DIFF
--- a/ui/src/main/webapp/app/query/input-manager/input-manager-component.js
+++ b/ui/src/main/webapp/app/query/input-manager/input-manager-component.js
@@ -70,7 +70,7 @@ function InputManagerController(events, results, common, types, schema) {
             vm.model.inputB = [];
             vm.model.inputPairs = [];
         }
-        vm.model.overriddenSeedType = '';
+        vm.model.seedType = '';
     }
 
     /**

--- a/ui/src/main/webapp/app/query/input-manager/input-manager-component.js
+++ b/ui/src/main/webapp/app/query/input-manager/input-manager-component.js
@@ -63,11 +63,14 @@ function InputManagerController(events, results, common, types, schema) {
     vm.onCheckboxChange = function() {
         if (vm.usePreviousOutput) {
             vm.model.input = null;
+            vm.model.inputB = null;
             vm.model.inputPairs = null;
         } else {
             vm.model.input = [];
+            vm.model.inputB = [];
             vm.model.inputPairs = [];
         }
+        vm.model.overriddenSeedType = '';
     }
 
     /**

--- a/ui/src/main/webapp/app/query/input-manager/input-manager.html
+++ b/ui/src/main/webapp/app/query/input-manager/input-manager.html
@@ -23,7 +23,7 @@
                 </md-button>
             </div>
             <div layout="row" class="horizontal-margin">
-                <seed-builder model="ctrl.model.input"
+                <seed-builder model="ctrl.model"
                               use-previous="ctrl.usePreviousOutput"
                               route-param="input" flex="grow"></seed-builder>
                 <seed-builder model="ctrl.model.inputB"

--- a/ui/src/main/webapp/app/query/input-manager/seed-builder/seed-builder-component.js
+++ b/ui/src/main/webapp/app/query/input-manager/seed-builder/seed-builder-component.js
@@ -48,6 +48,11 @@ function seedBuilder() {
 function SeedBuilderController(schema, csv, types, error, events, common, $routeParams, $location) {
     var vm = this;
     vm.seedVertices = '';
+    vm.overrideSeedType = false
+    vm.overriddenSeedType = ''
+    vm.seedTypes = ('Entity Object').split(' ').map(function (seedType) {
+        return {value: seedType};
+    })
 
     vm.$onInit = function() {
         schema.get().then(function(gafferSchema) {
@@ -55,7 +60,7 @@ function SeedBuilderController(schema, csv, types, error, events, common, $route
             if(vertices && vertices.length > 0 && undefined !== vertices[0]) {
                 vm.vertexClass = gafferSchema.types[vertices[0]].class;
             }
-            recalculateSeeds(vm.model);
+            recalculateSeeds(vm.model.input);
             if($routeParams[vm.routeParam]) {
                 if(Array.isArray($routeParams[vm.routeParam])) {
                     vm.seedVertices += '\n' + $routeParams[vm.routeParam].join('\n');
@@ -65,15 +70,20 @@ function SeedBuilderController(schema, csv, types, error, events, common, $route
                 vm.addSeeds(true);
                 $location.search(vm.routeParam, null);
             }
-
         });
 
         events.subscribe('onPreExecute', vm.addSeeds);
         events.subscribe('onOperationUpdate', onOperationUpdate);
     }
 
+    vm.onCheckboxChange = function() {
+        if (!vm.overrideSeedType) {
+            vm.overriddenSeedType = ''
+        }
+    }
+
     var onOperationUpdate = function() {
-        recalculateSeeds(vm.model);
+        recalculateSeeds(vm.model.input);
     }
 
     /**
@@ -168,7 +178,8 @@ function SeedBuilderController(schema, csv, types, error, events, common, $route
         if (vm.seedForm) {
             vm.seedForm.multiSeedInput.$setValidity('csv', true)
         }
-        vm.model = deduped;
+        vm.model.input = deduped
+        vm.model.overriddenSeedType = vm.overriddenSeedType
     }
 
     /**
@@ -245,9 +256,7 @@ function SeedBuilderController(schema, csv, types, error, events, common, $route
         vm.seedVertices = str.slice(0, -1);
     }
 
-
     var createSeed = function(parts) {
-        var vertex = {valueClass: vm.vertexClass, parts: parts};
-        return vertex;
+        return {valueClass: vm.vertexClass, parts: parts};
     }
 }

--- a/ui/src/main/webapp/app/query/input-manager/seed-builder/seed-builder-component.js
+++ b/ui/src/main/webapp/app/query/input-manager/seed-builder/seed-builder-component.js
@@ -48,8 +48,8 @@ function seedBuilder() {
 function SeedBuilderController(schema, csv, types, error, events, common, $routeParams, $location) {
     var vm = this;
     vm.seedVertices = '';
-    vm.overrideSeedType = false
-    vm.overriddenSeedType = ''
+    vm.forceSeedType = false
+    vm.seedType = ''
     vm.seedTypes = ('Entity Object').split(' ').map(function (seedType) {
         return {value: seedType};
     })
@@ -77,8 +77,8 @@ function SeedBuilderController(schema, csv, types, error, events, common, $route
     }
 
     vm.onCheckboxChange = function() {
-        if (!vm.overrideSeedType) {
-            vm.overriddenSeedType = ''
+        if (!vm.forceSeedType) {
+            vm.seedType = ''
         }
     }
 
@@ -179,7 +179,7 @@ function SeedBuilderController(schema, csv, types, error, events, common, $route
             vm.seedForm.multiSeedInput.$setValidity('csv', true)
         }
         vm.model.input = deduped
-        vm.model.overriddenSeedType = vm.overriddenSeedType
+        vm.model.seedType = vm.seedType
     }
 
     /**

--- a/ui/src/main/webapp/app/query/input-manager/seed-builder/seed-builder.html
+++ b/ui/src/main/webapp/app/query/input-manager/seed-builder/seed-builder.html
@@ -15,14 +15,14 @@
             </div>
         </md-input-container>
         <md-input-container class="md-block">
-            <md-checkbox id="overrideSeedType" ng-model="ctrl.overrideSeedType"
+            <md-checkbox id="forceSeedType" ng-model="ctrl.forceSeedType"
                          ng-change="ctrl.onCheckboxChange()"
                          aria-label="Override the default seed type handling">
                 Override Seed Type
             </md-checkbox>
         </md-input-container>
-        <md-input-container ng-if="ctrl.overrideSeedType" class="md-block">
-            <md-select ng-model="ctrl.overriddenSeedType" required class="no-ellipsis" placeholder="Override seed type">
+        <md-input-container ng-if="ctrl.forceSeedType" class="md-block">
+            <md-select ng-model="ctrl.seedType" required class="no-ellipsis" placeholder="Override seed type">
                 <md-option ng-repeat="seedType in ctrl.seedTypes" ng-value="seedType.value">
                     {{ seedType.value }}
                 </md-option>

--- a/ui/src/main/webapp/app/query/input-manager/seed-builder/seed-builder.html
+++ b/ui/src/main/webapp/app/query/input-manager/seed-builder/seed-builder.html
@@ -2,17 +2,31 @@
     <ng-form name="ctrl.seedForm">
         <md-input-container id="Multiple Seed input" class="md-block" flex md-no-float>
             <textarea id="seedVertices"
-                        rows="6"
-                        name="multiSeedInput"
-                        md-no-autogrow
-                        ng-disabled="ctrl.usePrevious"
-                        ng-model="ctrl.seedVertices"
-                        ng-blur="ctrl.addSeeds()"
-                        placeholder="{{ctrl.getPlaceHolder()}}">
+                      rows="6"
+                      name="multiSeedInput"
+                      md-no-autogrow
+                      ng-disabled="ctrl.usePrevious"
+                      ng-model="ctrl.seedVertices"
+                      ng-blur="ctrl.addSeeds()"
+                      placeholder="{{ctrl.getPlaceHolder()}}">
             </textarea>
             <div ng-messages="ctrl.seedForm.multiSeedInput.$error">
                 <div ng-message="csv">Your CSV is invalid</div>
             </div>
+        </md-input-container>
+        <md-input-container class="md-block">
+            <md-checkbox id="overrideSeedType" ng-model="ctrl.overrideSeedType"
+                         ng-change="ctrl.onCheckboxChange()"
+                         aria-label="Override the default seed type handling">
+                Override Seed Type
+            </md-checkbox>
+        </md-input-container>
+        <md-input-container ng-if="ctrl.overrideSeedType" class="md-block">
+            <md-select ng-model="ctrl.overriddenSeedType" required class="no-ellipsis" placeholder="Override seed type">
+                <md-option ng-repeat="seedType in ctrl.seedTypes" ng-value="seedType.value">
+                    {{ seedType.value }}
+                </md-option>
+            </md-select>
         </md-input-container>
     </ng-form>
 </div>

--- a/ui/src/main/webapp/app/query/operation-chain-component.js
+++ b/ui/src/main/webapp/app/query/operation-chain-component.js
@@ -280,7 +280,7 @@ function OperationChainController(operationChain, settings, config, loading, que
      * Uses seeds uploaded to the input service to build an input array to the query.
      * @param seeds the input array
      */
-    var createOpInput = function(seeds, overriddenSeedType, inputType) {
+    var createOpInput = function(seeds, seedType, inputType) {
         if (seeds === null || seeds === undefined || !inputType) {
             return undefined;
         }
@@ -297,8 +297,8 @@ function OperationChainController(operationChain, settings, config, loading, que
             opInput = [];
             var inputItemType = inputTypeName.substring(0, inputTypeName.length - 2);
 
-            if (overriddenSeedType) {
-                switch (overriddenSeedType) {
+            if (seedType) {
+                switch (seedType) {
                     case "Entity":
                         inputItemType = ENTITY_ID_CLASS;
                         break;
@@ -309,7 +309,7 @@ function OperationChainController(operationChain, settings, config, loading, que
             }
 
             // Assume the input type is EntityId if it is just Object or unknown.
-            if (!overriddenSeedType && (inputItemType === "" || inputItemType === "java.lang.Object")) {
+            if (!seedType && (inputItemType === "" || inputItemType === "java.lang.Object")) {
                 inputItemType = ENTITY_ID_CLASS;
             }
 
@@ -448,12 +448,12 @@ function OperationChainController(operationChain, settings, config, loading, que
             if (selectedOp.fields.input.className === PAIR_ARRAY_CLASS) {
                 op.input = createPairInput(operation.fields.inputPairs)
             } else {
-                op.input = createOpInput(operation.fields.input, operation.fields.overriddenSeedType, selectedOp.fields.input);
+                op.input = createOpInput(operation.fields.input, operation.fields.seedType, selectedOp.fields.input);
             }
         }
         
         if (selectedOp.fields.inputB && !selectedOp.namedOp) {
-            op.inputB = createOpInput(operation.fields.inputB, operation.fields.overriddenSeedType, selectedOp.fields.inputB);
+            op.inputB = createOpInput(operation.fields.inputB, operation.fields.seedType, selectedOp.fields.inputB);
         }
 
         if (selectedOp.parameters) {
@@ -472,7 +472,7 @@ function OperationChainController(operationChain, settings, config, loading, que
             if (!op.parameters) {
                 op.parameters = {};
             }
-            op.parameters['inputB'] = createOpInput(operation.fields.inputB, operation.fields.overriddenSeedType, selectedOp.fields.inputB);
+            op.parameters['inputB'] = createOpInput(operation.fields.inputB, operation.fields.seedType, selectedOp.fields.inputB);
         }
 
         if (selectedOp.fields.view) {

--- a/ui/src/test/webapp/app/query/input-manager/seed-builder/seed-builder-component-integration-spec.js
+++ b/ui/src/test/webapp/app/query/input-manager/seed-builder/seed-builder-component-integration-spec.js
@@ -14,7 +14,7 @@ describe('The Seed Builder', function() {
         types = _types_;
         error = _error_;
         ctrl = _$componentController_('seedBuilder', null, {
-            model: [],
+            model: { input: [] },
         });
     }));
 
@@ -83,7 +83,7 @@ describe('The Seed Builder', function() {
 
     
     var fireEvent = function(newInput) {
-        ctrl.model = newInput;
+        ctrl.model.input = newInput;
         events.broadcast(OPERATION_UPDATE_EVENT, []);
     }
 
@@ -266,11 +266,11 @@ describe('The Seed Builder', function() {
     });
 
     it('should add the seeds if it receives a "onPreExecute" event', function() {
-        expect(ctrl.model).toEqual([]);
+        expect(ctrl.model.input).toEqual([]);
         ctrl.vertexClass='java.lang.String';
         ctrl.seedVertices = 'M5\nM32:1';
         events.broadcast('onPreExecute', []);
-        expect(ctrl.model).toEqual([
+        expect(ctrl.model.input).toEqual([
             {
                 valueClass: 'java.lang.String',
                 parts: {
@@ -284,8 +284,5 @@ describe('The Seed Builder', function() {
                 }
             }
         ])
-
     })
-
-
 })

--- a/ui/src/test/webapp/app/query/input-manager/seed-builder/seed-builder-component-spec.js
+++ b/ui/src/test/webapp/app/query/input-manager/seed-builder/seed-builder-component-spec.js
@@ -105,7 +105,7 @@ describe('The seed builder component', function() {
                 }
             ]);
 
-            ctrl.model = [
+            ctrl.model.input = [
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -132,7 +132,7 @@ describe('The seed builder component', function() {
                 ctrl.$onInit();
                 scope.$digest();
                 expect(error.handle).not.toHaveBeenCalled();
-                expect(ctrl.model).toEqual([{
+                expect(ctrl.model.input).toEqual([{
                     valueClass: 'my.vertex.Class',
                     parts: {
                         undefined: "seed1"
@@ -145,7 +145,7 @@ describe('The seed builder component', function() {
                 ctrl.$onInit();
                 scope.$digest();
                 expect(error.handle).not.toHaveBeenCalled();
-                expect(ctrl.model).toEqual([{
+                expect(ctrl.model.input).toEqual([{
                         valueClass: 'my.vertex.Class',
                         parts: {
                             undefined: "seed1"
@@ -178,7 +178,7 @@ describe('The seed builder component', function() {
                 ctrl.$onInit();
                 scope.$digest();
                 expect(error.handle).not.toHaveBeenCalled();
-                expect(ctrl.model).toEqual([
+                expect(ctrl.model.input).toEqual([
                     {
                         valueClass: 'my.vertex.Class',
                         parts: {"type": "t1", "value": "v1"}
@@ -191,7 +191,7 @@ describe('The seed builder component', function() {
                 ctrl.$onInit();
                 scope.$digest();
                 expect(error.handle).not.toHaveBeenCalled();
-                expect(ctrl.model).toEqual([
+                expect(ctrl.model.input).toEqual([
                     {
                         valueClass: 'my.vertex.Class',
                         parts: {"type": "t1", "value": "v1"}
@@ -213,7 +213,7 @@ describe('The seed builder component', function() {
                     'required': true
                 }
             ])
-            ctrl.model = [
+            ctrl.model.input = [
                 {
                     valueClass: 'java.lang.Integer',
                     parts: {
@@ -232,7 +232,7 @@ describe('The seed builder component', function() {
                 { key: 'subType' },
                 { key: 'value' }
             ])
-            ctrl.model = [
+            ctrl.model.input = [
                 {
                     valueClass: 'uk.gov.gchq.gaffer.types.TypeSubTypeValue',
                     parts: {
@@ -255,7 +255,7 @@ describe('The seed builder component', function() {
                     'label': ''
                 }
             ]);
-            ctrl.model = [
+            ctrl.model.input = [
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -365,7 +365,7 @@ describe('The seed builder component', function() {
                 }
             ]
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -387,7 +387,7 @@ describe('The seed builder component', function() {
                 }
             ]
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.Long',
                     parts: {
@@ -407,7 +407,7 @@ describe('The seed builder component', function() {
                 class: 'java.lang.Boolean'
             }];
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.Boolean',
                     parts: {
@@ -427,7 +427,7 @@ describe('The seed builder component', function() {
             }];
 
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.Boolean',
                     parts: {
@@ -442,7 +442,7 @@ describe('The seed builder component', function() {
             ctrl.vertexClass = 'java.lang.String';
             ctrl.seedVertices = '"comma,test"';
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -461,7 +461,7 @@ describe('The seed builder component', function() {
                 class: 'java.lang.String'
             }];
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -484,7 +484,7 @@ describe('The seed builder component', function() {
 
             ctrl.addSeeds();
 
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'customClass',
                     parts: {
@@ -500,7 +500,7 @@ describe('The seed builder component', function() {
             ctrl.vertexClass = 'java.lang.String';
             ctrl.seedVertices = '"I contain a \\"quoted string\\""',
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -515,7 +515,7 @@ describe('The seed builder component', function() {
             ctrl.vertexClass = 'java.lang.String';
             ctrl.seedVertices = '"I contain a \\\\string with \\\\ escape characters"',
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -558,14 +558,14 @@ describe('The seed builder component', function() {
             ctrl.vertexClass = 'java.lang.String';
             ctrl.seedVertices = '',
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([]);
+            expect(ctrl.model.input).toEqual([]);
         });
 
         it('should add empty strings', function() {
             ctrl.vertexClass = 'java.lang.String';
             ctrl.seedVertices = '""',
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -581,7 +581,7 @@ describe('The seed builder component', function() {
             ctrl.seedVertices = 'This is a \\"test\\"';
             ctrl.addSeeds();
 
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -597,7 +597,7 @@ describe('The seed builder component', function() {
             ctrl.seedVertices = 'This is a \\\\test\\\\';
             ctrl.addSeeds();
 
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -613,7 +613,7 @@ describe('The seed builder component', function() {
             ctrl.seedVertices = '"This is a \\\\test"';
             ctrl.addSeeds();
 
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -629,7 +629,7 @@ describe('The seed builder component', function() {
             ctrl.seedVertices = 'This is a \\test';
             ctrl.addSeeds();
 
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -677,7 +677,7 @@ describe('The seed builder component', function() {
             ctrl.vertexClass = 'java.lang.String';
             ctrl.seedVertices = '1';
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -697,7 +697,7 @@ describe('The seed builder component', function() {
             ctrl.vertexClass = 'java.lang.String';
             ctrl.seedVertices='test\ntest\ntest';
             ctrl.addSeeds();
-            expect(ctrl.model).toEqual([
+            expect(ctrl.model.input).toEqual([
                 {
                     valueClass: 'java.lang.String',
                     parts: {
@@ -733,7 +733,7 @@ describe('The seed builder component', function() {
                 ctrl.seedVertices = 'T,,';
                 ctrl.addSeeds();
                 expect(error.handle).not.toHaveBeenCalled();
-                expect(ctrl.model).toEqual([{
+                expect(ctrl.model.input).toEqual([{
                     valueClass: 'TypeSubTypeValue',
                     parts: {
                         'type': 'T',
@@ -748,7 +748,7 @@ describe('The seed builder component', function() {
                 ctrl.seedVertices = '"My type",,""';
                 ctrl.addSeeds();
                 expect(error.handle).not.toHaveBeenCalled();
-                expect(ctrl.model).toEqual([{
+                expect(ctrl.model.input).toEqual([{
                     valueClass: 'TypeSubTypeValue',
                     parts: {
                         'type': 'My type',
@@ -763,7 +763,7 @@ describe('The seed builder component', function() {
                 ctrl.seedVertices = '';
                 ctrl.addSeeds();
                 expect(error.handle).not.toHaveBeenCalled();
-                expect(ctrl.model).toEqual([]);
+                expect(ctrl.model.input).toEqual([]);
                 expect(ctrl.seedForm.multiSeedInput.$setValidity).toHaveBeenCalledWith('csv', true);
             });
 
@@ -771,7 +771,7 @@ describe('The seed builder component', function() {
                 ctrl.seedVertices = 'T';
                 ctrl.addSeeds();
                 expect(error.handle).not.toHaveBeenCalled();
-                expect(ctrl.model).toEqual([{
+                expect(ctrl.model.input).toEqual([{
                     valueClass: 'TypeSubTypeValue',
                     parts: {
                         'type': 'T',
@@ -786,7 +786,7 @@ describe('The seed builder component', function() {
                 ctrl.seedVertices = '1,2,3';
                 ctrl.addSeeds();
                 expect(error.handle).not.toHaveBeenCalled();
-                expect(ctrl.model).toEqual([
+                expect(ctrl.model.input).toEqual([
                     {
                         valueClass: 'TypeSubTypeValue',
                         parts: {
@@ -803,7 +803,7 @@ describe('The seed builder component', function() {
                 ctrl.seedVertices='1,2,3\n1,2,3';
                 ctrl.addSeeds();
                 expect(error.handle).toHaveBeenCalled();
-                expect(ctrl.model).toEqual([
+                expect(ctrl.model.input).toEqual([
                     {
                         valueClass: 'TypeSubTypeValue',
                         parts: {

--- a/ui/src/test/webapp/app/query/operation-chain-component-spec.js
+++ b/ui/src/test/webapp/app/query/operation-chain-component-spec.js
@@ -1087,7 +1087,7 @@ describe('The operation chain component', function() {
                         selectedOperation: {
                             fields: {
                                 input: {},
-                                overriddenSeedType: ''
+                                seedType: ''
                             }
                         },
                         fields: {
@@ -1175,7 +1175,7 @@ describe('The operation chain component', function() {
                             {valueClass: 'java.lang.String', parts: {undefined: 'test3'}}
                         ];
 
-                        op.fields.overriddenSeedType = "Object";
+                        op.fields.seedType = "Object";
 
                         var expectedInput = JSON.stringify(['test1', 'test2', 'test3']);
 
@@ -1190,7 +1190,7 @@ describe('The operation chain component', function() {
                             {valueClass: 'java.lang.String', parts: {undefined: 'test3'}}
                         ];
 
-                        op.fields.overriddenSeedType = "Entity";
+                        op.fields.seedType = "Entity";
 
                         var expectedInput = JSON.stringify([
                             { 'class': 'uk.gov.gchq.gaffer.operation.data.EntitySeed', 'vertex': 'test1'},

--- a/ui/src/test/webapp/app/query/operation-chain-component-spec.js
+++ b/ui/src/test/webapp/app/query/operation-chain-component-spec.js
@@ -331,7 +331,7 @@ describe('The operation chain component', function() {
 
             expect(json.class).toEqual("uk.gov.gchq.gaffer.operation.OperationChain");
         });
-        
+
         it('should not save if a name has not been entered', function() {
             ctrl.namedOperationName = '';
             ctrl.namedOperationDescription = 'test description';
@@ -347,9 +347,9 @@ describe('The operation chain component', function() {
             ctrl.operations.length = 1;
 
             var invalidName = $mdDialog.confirm()
-            .title('Operation chain name is invalid!')
-            .textContent('You must provide a name for the operation')
-            .ok('Ok')
+                .title('Operation chain name is invalid!')
+                .textContent('You must provide a name for the operation')
+                .ok('Ok')
 
             ctrl.saveChain();
 
@@ -386,9 +386,9 @@ describe('The operation chain component', function() {
             ctrl.operations.length = 1;
 
             var confirm = $mdDialog.confirm()
-            .title('Operation chain saved as named operation!')
-            .textContent('You can now see your saved operation in the list of operations')
-            .ok('Ok')
+                .title('Operation chain saved as named operation!')
+                .textContent('You can now see your saved operation in the list of operations')
+                .ok('Ok')
 
             ctrl.saveChain();
 
@@ -572,12 +572,11 @@ describe('The operation chain component', function() {
                         },
                         dates: {}
                     }
-    
+
                     ctrl.execute(op);
                     expect(JSON.stringify(query.execute.calls.first().args[0])).not.toContain('"groupBy":[]');
                 });
             });
-
 
             describe('When adding Named views', function() {
 
@@ -1087,11 +1086,13 @@ describe('The operation chain component', function() {
                     op = {
                         selectedOperation: {
                             fields: {
-                                input: {}
+                                input: {},
+                                overriddenSeedType: ''
                             }
                         },
                         fields: {
                             input: [],
+                            inputB: {},
                             inputPairs: []
                         }
                     }
@@ -1163,7 +1164,42 @@ describe('The operation chain component', function() {
                         { 'class': 'uk.gov.gchq.gaffer.operation.data.EntitySeed', 'vertex': 3}])
 
                     expect(JSON.stringify(query.execute.calls.first().args[0])).toContain(expectedInput);
+                });
 
+                describe('When overriding the seed type', function () {
+
+                    it('should be able to force an input seed type of java.lang.Object', function () {
+                        op.fields.input = [
+                            {valueClass: 'java.lang.String', parts: {undefined: 'test1'}},
+                            {valueClass: 'java.lang.String', parts: {undefined: 'test2'}},
+                            {valueClass: 'java.lang.String', parts: {undefined: 'test3'}}
+                        ];
+
+                        op.fields.overriddenSeedType = "Object";
+
+                        var expectedInput = JSON.stringify(['test1', 'test2', 'test3']);
+
+                        ctrl.execute(op);
+                        expect(JSON.stringify(query.execute.calls.first().args[0])).toContain(expectedInput);
+                    })
+
+                    it('should be able to force an input seed type of EntitySeed', function () {
+                        op.fields.input = [
+                            {valueClass: 'java.lang.String', parts: {undefined: 'test1'}},
+                            {valueClass: 'java.lang.String', parts: {undefined: 'test2'}},
+                            {valueClass: 'java.lang.String', parts: {undefined: 'test3'}}
+                        ];
+
+                        op.fields.overriddenSeedType = "Entity";
+
+                        var expectedInput = JSON.stringify([
+                            { 'class': 'uk.gov.gchq.gaffer.operation.data.EntitySeed', 'vertex': 'test1'},
+                            { 'class': 'uk.gov.gchq.gaffer.operation.data.EntitySeed', 'vertex': 'test2'},
+                            { 'class': 'uk.gov.gchq.gaffer.operation.data.EntitySeed', 'vertex': 'test3'}])
+
+                        ctrl.execute(op);
+                        expect(JSON.stringify(query.execute.calls.first().args[0])).toContain(expectedInput);
+                    })
                 });
 
                 describe('When adding a second input', function() {
@@ -1247,11 +1283,9 @@ describe('The operation chain component', function() {
                         expect(JSON.stringify(json.operations[0].parameters.inputB)).toEqual(expectedInput);
                     });
 
-
                 })
             });
         });
-
 
         it('should add the selected operation to the list of operations', function() {
             var op = {
@@ -1820,7 +1854,7 @@ describe('The operation chain component', function() {
 
             ctrl.executeChain();
 
-            expect(operationChain.getOperationChain).toHaveBeenCalledTimes(1);            
+            expect(operationChain.getOperationChain).toHaveBeenCalledTimes(1);
         });
     });
 


### PR DESCRIPTION
* Added some new sub-components to the `<seed-builder>` component to allow users to override the seed type that is inferred by the UI when submitting operations to Gaffer.
* If the override behaviour is selected, a new field value (`overriddenSeedType`) is propagated through to the `OperationChainController`, where it is used to change the seed formatting.
* Added new tests and updated old tests.

Notes:

* Currently this approach doesn't support supplying mixed seed types in a single operation (e.g. being able to submit a `GetElements` operation through the UI which contains input with correctly formatted `EdgeSeeds` and `EntitySeeds`). All input seeds must be overridden to the same type.
* When submitting an operation which contains multiple inputs (`input` and `inputB`), if the input seed type is overridden then this will apply to both `input` and `inputB`.
* `EdgeSeeds` are still unsupported when using the UI.

# Related Issue

- Resolve #927