### PR TITLE
gh-896: Tidy up gafferpy parameter validation

### DIFF
--- a/python-shell/src/gafferpy/gaffer_core.py
+++ b/python-shell/src/gafferpy/gaffer_core.py
@@ -478,6 +478,21 @@ class JsonConverter:
 
         return obj
 
+    @staticmethod
+    def validate(obj, expected_class, allow_none=True):
+        if obj is None:
+            if allow_none:
+                return None
+            raise TypeError('Argument must be of type ' + str(expected_class))
+        if not issubclass(expected_class, ToJson):
+            raise TypeError(str(expected_class) + ' must inherit ToJson')
+        if not isinstance(obj, ToJson):
+            obj = JsonConverter.from_json(obj, expected_class)
+        if not isinstance(obj, expected_class):
+            raise TypeError(str(obj) + ' must be of type ' +
+                                                        str(expected_class))
+        return obj
+
 
 def load_core_json_map():
     for name, class_obj in inspect.getmembers(


### PR DESCRIPTION
This PR updates the pattern of validating and assigning parameters from something like:
https://github.com/gchq/gaffer-tools/blob/1d4074367f616d0d6ed32244eb5da9b67c5dcb4a/python-shell/src/gafferpy/gaffer_operations.py#L2320-L2328
to:
https://github.com/gchq/gaffer-tools/blob/97e8185b605b84ac625c54d0565a72bda3fc0b37/python-shell/src/gafferpy/gaffer_operations.py#L2306

Not only does this clean up the code base and offer a unified way of validating inputs, it cleans up a lot of bugs where this was done not quite right.

# Related Issue

- Resolve #896